### PR TITLE
Typo correction in definition of constructor RefData

### DIFF
--- a/src/wxchartlabeloptions.cpp
+++ b/src/wxchartlabeloptions.cpp
@@ -22,7 +22,7 @@
 
 #include "wxchartlabeloptions.h"
 
-wxChartLabelOptions::wxChartLabelOptions::RefData::RefData(const wxChartFontOptions &fontOptions,
+wxChartLabelOptions::RefData::RefData(const wxChartFontOptions &fontOptions,
                                                            bool hasBackground,
                                                            const wxChartBackgroundOptions &backgroundOptions)
     : m_fontOptions(fontOptions), m_hasBackground(hasBackground),


### PR DESCRIPTION
Removed the error in the definition of constructor RefData in file wxchartlabeloptions.cpp.