### PR TITLE
add saving in SVG

### DIFF
--- a/include/wx/charts/wxlinechartctrl.h
+++ b/include/wx/charts/wxlinechartctrl.h
@@ -169,6 +169,7 @@ public:
 
 	void Draw(wxGraphicsContext &gc);
 	void Save(const wxString &filename, const wxBitmapType &type);
+	wxBitmap CreateBitmap();
 
 private:
 	void Initialize(const wxLineChartData &data);

--- a/src/wxlinechartctrl.cpp
+++ b/src/wxlinechartctrl.cpp
@@ -448,15 +448,21 @@ void wxLineChartCtrl::Draw(wxGraphicsContext &gc)
 
 void wxLineChartCtrl::Save(const wxString &filename, const wxBitmapType &type)
 {
-    int w,h;
+    CreateBitmap().SaveFile(filename,type);
+}
+
+wxBitmap wxLineChartCtrl::CreateBitmap()
+{
+	int w,h;
     GetSize(&w,&h);
     wxBitmap bmp(w,h);
     wxMemoryDC mdc(bmp);
     mdc.Clear();
     wxGraphicsContext* gc = wxGraphicsContext::Create(mdc);
     Draw(*gc);
-    bmp.SaveFile(filename,type);
     delete gc;
+
+	return bmp;
 }
 
 void wxLineChartCtrl::OnPaint(wxPaintEvent &evt)

--- a/src/wxlinechartctrl.cpp
+++ b/src/wxlinechartctrl.cpp
@@ -275,7 +275,7 @@ void wxLineChartCtrl::CreateContextMenu()
         [this](wxCommandEvent &)
         {
             wxFileDialog saveFileDialog(this, _("Save file"), "", "",
-                "JPEG files (*.jpg;*.jpeg)|*.jpg;*.jpeg|PNG files (*.png)|*.png",
+                "JPEG files (*.jpg;*.jpeg)|*.jpg;*.jpeg|PNG files (*.png)|*.png|SVG files (*.svg)|*.svg",
                 wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
             if (saveFileDialog.ShowModal() == wxID_CANCEL)
                 return;
@@ -287,7 +287,7 @@ void wxLineChartCtrl::CreateContextMenu()
             {
             case 0:
                 type = wxBitmapType::wxBITMAP_TYPE_JPEG;
-                if (wxImage::FindHandler(wxBitmapType::wxBITMAP_TYPE_JPEG) == 0)
+                if (wxImage::FindHandler(type) == 0)
                 {
                     wxImage::AddHandler(new wxJPEGHandler());
                 }
@@ -295,11 +295,29 @@ void wxLineChartCtrl::CreateContextMenu()
 
             case 1:
                 type = wxBitmapType::wxBITMAP_TYPE_PNG;
-                if (wxImage::FindHandler(wxBitmapType::wxBITMAP_TYPE_PNG) == 0)
+                if (wxImage::FindHandler(type) == 0)
                 {
                     wxImage::AddHandler(new wxPNGHandler());
                 }
                 break;
+
+            case 2:
+				//auto bmp = this->CreateBitmap();
+
+				type = wxBitmapType::wxBITMAP_TYPE_JPEG;
+				if (wxImage::FindHandler(type) == 0)
+                {
+                    wxImage::AddHandler(new wxJPEGHandler());
+                }
+				auto testfile = "testfile";
+				this->CreateBitmap().SaveFile(testfile,type);
+				auto bmp = wxBitmap(testfile,type);
+
+				wxSVGFileDC svgDC(filename,bmp.GetWidth(),bmp.GetHeight());
+				svgDC.SetBitmapHandler(new wxSVGBitmapEmbedHandler());
+				svgDC.DrawBitmap(bmp,0,0);
+				wxRemoveFile(testfile);
+                return;
             }
             
             Save(filename, type);


### PR DESCRIPTION
this probably will help for close  #7 

Theoretically should work this:

`auto bmp = this->CreateBitmap();
...
`

but I get incorrect result. I suppose this is due to the fact that wxBITMAP_DEFAULT_TYPE in my case is wxBITMAP_TYPE_BMP_RESOURCE. I have not found a way to set this type as parameter to the appropriate constructor or method for setting it afterwards. So I suggested another alternative, requiring the creation of a temporary file, but leading to the correct result.
However first way was left as a comment.