### PR TITLE
Compilation fix for VS2019

### DIFF
--- a/include/wx/charts/wxchartselement.h
+++ b/include/wx/charts/wxchartselement.h
@@ -75,7 +75,7 @@ public:
     virtual wxPoint2DDouble GetTooltipPosition() const = 0;
 
 private:
-    const wxChartTooltipProvider::ptr m_tooltipProvider;
+    wxChartTooltipProvider::ptr m_tooltipProvider;
 };
 
 #endif


### PR DESCRIPTION
removing the `const` for the offending member shuts up latest MSVC2019.

(https://github.com/wxIshiko/wxCharts/issues/173 was only triggered in 64bit builds on my dev box, by the way)
